### PR TITLE
Feature add dark mode toggle

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
-    implementation("androidx.compose.material:material-icons-extended")
+    implementation(libs.androidx.material.icons.extended)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation("androidx.compose.material:material-icons-extended")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/example/booktracker/MainActivity.kt
+++ b/app/src/main/java/com/example/booktracker/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.example.booktracker
 
 import android.os.Bundle
+import androidx.core.view.WindowCompat
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -12,7 +13,6 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import com.example.booktracker.data.Book
@@ -46,6 +46,15 @@ fun BookTrackerApp() {
     var isDarkMode by remember {
         mutableStateOf(themePrefs.isDarkMode())
     }
+
+    // Update status bar appearance when theme changes
+    LaunchedEffect(isDarkMode) {
+        val activity = context as ComponentActivity
+        WindowCompat.getInsetsController(activity.window, activity.window.decorView).apply {
+            isAppearanceLightStatusBars = !isDarkMode
+        }
+    }
+
     //Wrap inside dark theme
     BookTrackerTheme(darkTheme = isDarkMode) {
         //Initialize database and book repository

--- a/app/src/main/java/com/example/booktracker/MainActivity.kt
+++ b/app/src/main/java/com/example/booktracker/MainActivity.kt
@@ -88,7 +88,10 @@ fun BookTrackerApp() {
                             if (!isSearching) searchQuery = ""
                         },
                         isDarkMode = isDarkMode,
-                        onDarkModeToggle = { isDarkMode = !isDarkMode }
+                        onDarkModeToggle = {
+                            isDarkMode = !isDarkMode
+                            themePrefs.setDarkMode(isDarkMode)
+                        }
                     )
                 }
             },

--- a/app/src/main/java/com/example/booktracker/MainActivity.kt
+++ b/app/src/main/java/com/example/booktracker/MainActivity.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.launch
 import com.example.booktracker.data.Book
 import com.example.booktracker.data.BookRepository
 import com.example.booktracker.data.BookDatabase
+import com.example.booktracker.data.ThemePreferences
 import com.example.booktracker.ui.theme.BookTrackerTheme
 import com.example.booktracker.ui.theme.screens.AddBookScreen
 import com.example.booktracker.ui.theme.screens.BookDetailScreen
@@ -57,7 +58,7 @@ fun BookTrackerApp() {
         var selectedBook by remember { mutableStateOf<Book?>(null) }
         var isSearching by remember { mutableStateOf(false) }
         var searchQuery by remember { mutableStateOf("") }
-       
+
         // Collect books from flow (this replaces repository.books list)
         val books by repository.books.collectAsState(initial = emptyList())
 

--- a/app/src/main/java/com/example/booktracker/MainActivity.kt
+++ b/app/src/main/java/com/example/booktracker/MainActivity.kt
@@ -38,6 +38,13 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 fun BookTrackerApp() {
+    //Dark mode state
+    var isDarkMode by remember { mutableStateOf(false) }
+    val systemDarkMode = isSystemInDarkTheme()
+
+    LaunchedEffect(Unit) {
+        isDarkMode = systemDarkMode
+    }
     //Initialize database and book repository
     val context = androidx.compose.ui.platform.LocalContext.current
     val repository = remember {

--- a/app/src/main/java/com/example/booktracker/MainActivity.kt
+++ b/app/src/main/java/com/example/booktracker/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import com.example.booktracker.data.Book
@@ -29,7 +30,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            BookTrackerTheme {
+            BookTrackerTheme(darkTheme = isDarkMode) {
                 BookTrackerApp()
             }
         }
@@ -48,6 +49,11 @@ fun BookTrackerApp() {
     var selectedBook by remember { mutableStateOf<Book?>(null) }
     var isSearching by remember { mutableStateOf(false) }
     var searchQuery by remember { mutableStateOf("") }
+    var isDarkMode by remember { mutableStateOf(false) }
+    val systemDarkMode = isSystemInDarkTheme()
+    LaunchedEffect(Unit) {
+        isDarkMode = systemDarkMode
+    }
 
     // Collect books from flow (this replaces repository.books list)
     val books by repository.books.collectAsState(initial = emptyList())
@@ -76,7 +82,9 @@ fun BookTrackerApp() {
                     onSearchToggle = {
                         isSearching = !isSearching
                         if (!isSearching) searchQuery = ""
-                    }
+                    },
+                    isDarkMode = isDarkMode,
+                    onDarkModeToggle = { isDarkMode = !isDarkMode }
                 )
             }
         },

--- a/app/src/main/java/com/example/booktracker/MainActivity.kt
+++ b/app/src/main/java/com/example/booktracker/MainActivity.kt
@@ -49,7 +49,6 @@ fun BookTrackerApp() {
     //Wrap inside dark theme
     BookTrackerTheme(darkTheme = isDarkMode) {
         //Initialize database and book repository
-        val context = androidx.compose.ui.platform.LocalContext.current
         val repository = remember {
             val database = BookDatabase.getDatabase(context)
             BookRepository(database.bookDao())

--- a/app/src/main/java/com/example/booktracker/MainActivity.kt
+++ b/app/src/main/java/com/example/booktracker/MainActivity.kt
@@ -30,12 +30,11 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            BookTrackerTheme(darkTheme = isDarkMode) {
-                BookTrackerApp()
-            }
+            BookTrackerApp()
         }
     }
 }
+
 
 @Composable
 fun BookTrackerApp() {

--- a/app/src/main/java/com/example/booktracker/MainActivity.kt
+++ b/app/src/main/java/com/example/booktracker/MainActivity.kt
@@ -39,12 +39,12 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 fun BookTrackerApp() {
-    //Dark mode state
-    var isDarkMode by remember { mutableStateOf(false) }
-    val systemDarkMode = isSystemInDarkTheme()
+    //Dark mode state gets saved after restating the app
+    val context = androidx.compose.ui.platform.LocalContext.current
+    val themePrefs = remember { ThemePreferences(context) }
 
-    LaunchedEffect(Unit) {
-        isDarkMode = systemDarkMode
+    var isDarkMode by remember {
+        mutableStateOf(themePrefs.isDarkMode())
     }
     //Wrap inside dark theme
     BookTrackerTheme(darkTheme = isDarkMode) {

--- a/app/src/main/java/com/example/booktracker/MainActivity.kt
+++ b/app/src/main/java/com/example/booktracker/MainActivity.kt
@@ -57,12 +57,7 @@ fun BookTrackerApp() {
         var selectedBook by remember { mutableStateOf<Book?>(null) }
         var isSearching by remember { mutableStateOf(false) }
         var searchQuery by remember { mutableStateOf("") }
-        var isDarkMode by remember { mutableStateOf(false) }
-        val systemDarkMode = isSystemInDarkTheme()
-        LaunchedEffect(Unit) {
-            isDarkMode = systemDarkMode
-        }
-
+       
         // Collect books from flow (this replaces repository.books list)
         val books by repository.books.collectAsState(initial = emptyList())
 

--- a/app/src/main/java/com/example/booktracker/data/ThemePreferences.kt
+++ b/app/src/main/java/com/example/booktracker/data/ThemePreferences.kt
@@ -1,0 +1,17 @@
+package com.example.booktracker.data
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+
+class ThemePreferences(context: Context) {
+    private val prefs: SharedPreferences = context.getSharedPreferences("theme_prefs", Context.MODE_PRIVATE)
+
+    fun isDarkMode(): Boolean {
+        return prefs.getBoolean("dark_mode", false) // Default to light mode
+    }
+
+    fun setDarkMode(isDark: Boolean) {
+        prefs.edit { putBoolean("dark_mode", isDark) }
+    }
+}

--- a/app/src/main/java/com/example/booktracker/ui/theme/components/SearchTopBar.kt
+++ b/app/src/main/java/com/example/booktracker/ui/theme/components/SearchTopBar.kt
@@ -39,6 +39,14 @@ fun SearchTopBar(
             }
         },
         actions = {
+            IconButton(onClick = onDarkModeToggle) {
+                Icon(
+                    imageVector = if (isDarkMode) Icons.Default.LightMode else Icons.Default.DarkMode,
+                    contentDescription = if (isDarkMode) "Switch to light theme" else "Switch to dark theme"
+                )
+            }
+
+
             IconButton(onClick = onSearchToggle) {
                 Icon(
                     imageVector = if (isSearching) Icons.Default.Close else Icons.Default.Search,

--- a/app/src/main/java/com/example/booktracker/ui/theme/components/SearchTopBar.kt
+++ b/app/src/main/java/com/example/booktracker/ui/theme/components/SearchTopBar.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.DarkMode
+import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier

--- a/app/src/main/java/com/example/booktracker/ui/theme/components/SearchTopBar.kt
+++ b/app/src/main/java/com/example/booktracker/ui/theme/components/SearchTopBar.kt
@@ -16,7 +16,9 @@ fun SearchTopBar(
     isSearching: Boolean,
     searchQuery: String,
     onSearchQueryChange: (String) -> Unit,
-    onSearchToggle: () -> Unit
+    onSearchToggle: () -> Unit,
+    isDarkMode: Boolean,
+    onDarkModeToggle: () -> Unit
 ) {
     TopAppBar(
         title = {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ roomRuntimeVersion = "2.7.2"
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 
+androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomRuntimeVersion" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "roomRuntimeVersion" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "roomRuntimeVersion" }


### PR DESCRIPTION
## Add Dark Mode Toggle with Theme Support

This update introduces a dark mode toggle in the top bar and enables persistent theme preference across app launches.

### Features

- Added dark mode toggle button to `SearchTopBar`
- Connected dark mode state to `BookTrackerApp` theme wrapper
- Moved dark mode state management to the top level of `BookTrackerApp`
- Updated `MainActivity` to remove redundant theme wrapping

### Theme Persistence

- Added `ThemePreferences` class to store user's theme preference
- Saved dark mode state on toggle and restored it on app launch
- Switched from `remember` to persistent state for dark mode handling

### Dependency Updates

- Added `material-icons-extended` dependency for toggle icons
- Refactored to use version catalog for managing material icon dependency

### Bug Fixes

- Fixed bug where theme toggle did not activate correctly
- Fixed status bar text visibility issue when switching themes
- Removed duplicate `context` variable declaration
