### PR TITLE
Feature add bottom navigations and discover section

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.material.icons.extended)
+    implementation(libs.androidx.navigation.compose)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/example/booktracker/MainActivity.kt
+++ b/app/src/main/java/com/example/booktracker/MainActivity.kt
@@ -23,6 +23,7 @@ import com.example.booktracker.data.ThemePreferences
 import com.example.booktracker.ui.theme.BookTrackerTheme
 import com.example.booktracker.ui.theme.screens.AddBookScreen
 import com.example.booktracker.ui.theme.screens.BookDetailScreen
+import com.example.booktracker.ui.theme.screens.DiscoverScreen
 import com.example.booktracker.ui.theme.components.BookListScreen
 import com.example.booktracker.ui.theme.components.SearchTopBar
 import androidx.navigation.compose.NavHost

--- a/app/src/main/java/com/example/booktracker/MainActivity.kt
+++ b/app/src/main/java/com/example/booktracker/MainActivity.kt
@@ -123,7 +123,8 @@ fun BookTrackerApp(onBooksLoaded: () -> Unit = {}) {
                         onDarkModeToggle = {
                             isDarkMode = !isDarkMode
                             themePrefs.setDarkMode(isDarkMode)
-                        }
+                        },
+                        currentDestination = currentDestination
                     )
                 }
             },

--- a/app/src/main/java/com/example/booktracker/MainActivity.kt
+++ b/app/src/main/java/com/example/booktracker/MainActivity.kt
@@ -149,7 +149,12 @@ fun BookTrackerApp(onBooksLoaded: () -> Unit = {}) {
                                     navController.navigate(destination.route)
                                 },
                                 icon = { Text(if (destination == BookTrackerDestination.MY_LIBRARY) "📚" else "🔍") },
-                                label = { Text(destination.title) }
+                                label = {
+                                    Text(
+                                        text = destination.title,
+                                        style = MaterialTheme.typography.bodyMedium
+                                    )
+                                }
                             )
                         }
                     }

--- a/app/src/main/java/com/example/booktracker/MainActivity.kt
+++ b/app/src/main/java/com/example/booktracker/MainActivity.kt
@@ -133,11 +133,12 @@ fun BookTrackerApp(onBooksLoaded: () -> Unit = {}) {
                 }
             },
             bottomBar = {
+                // if line hides to bottom bar based on add book and book detail screen activity
                 if (!showAddScreen && selectedBook == null) {
                     NavigationBar {
                         BookTrackerDestination.entries.forEach { destination ->
                             NavigationBarItem(
-                                selected = currentDestination == destination,
+                                selected = currentDestination ==destination,
                                 onClick = {
                                     currentDestination = destination
                                     navController.navigate(destination.route)

--- a/app/src/main/java/com/example/booktracker/MainActivity.kt
+++ b/app/src/main/java/com/example/booktracker/MainActivity.kt
@@ -31,6 +31,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 
+
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
@@ -183,11 +184,22 @@ fun BookTrackerApp(onBooksLoaded: () -> Unit = {}) {
                 }
 
                 else -> {
-                    BookListScreen(
-                        bookList = filteredBooks,
-                        modifier = Modifier.padding(innerPadding),
-                        onBookClick = { selectedBook = it }
-                    )
+                    NavHost(
+                        navController = navController,
+                        startDestination = BookTrackerDestination.MY_LIBRARY.route,
+                        modifier = Modifier.padding(innerPadding)
+                    ) {
+                        composable(BookTrackerDestination.MY_LIBRARY.route) {
+                            BookListScreen(
+                                bookList = filteredBooks,
+                                onBookClick = { selectedBook = it }
+                            )
+                        }
+
+                        composable(BookTrackerDestination.DISCOVER.route) {
+                            DiscoverScreen()
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/booktracker/MainActivity.kt
+++ b/app/src/main/java/com/example/booktracker/MainActivity.kt
@@ -129,7 +129,23 @@ fun BookTrackerApp(onBooksLoaded: () -> Unit = {}) {
                 FloatingActionButton(onClick = { showAddScreen = true }) {
                     Icon(Icons.Default.Add, contentDescription = "Add Book")
                 }
+            },
+            bottomBar = {
+                NavigationBar {
+                    BookTrackerDestination.entries.forEach { destination ->
+                        NavigationBarItem(
+                            selected = currentDestination ==destination,
+                            onClick = {
+                                currentDestination = destination
+                                navController.navigate(destination.route)
+                            },
+                            icon = { Text(if (destination == BookTrackerDestination.MY_LIBRARY) "📚" else "🔍") },
+                            label = { Text(destination.title) }
+                        )
+                    }
+                }
             }
+
         ) { innerPadding ->
             when {
                 showAddScreen -> {

--- a/app/src/main/java/com/example/booktracker/MainActivity.kt
+++ b/app/src/main/java/com/example/booktracker/MainActivity.kt
@@ -128,10 +128,14 @@ fun BookTrackerApp(onBooksLoaded: () -> Unit = {}) {
                 }
             },
             floatingActionButton = {
-                FloatingActionButton(onClick = { showAddScreen = true }) {
-                    Icon(Icons.Default.Add, contentDescription = "Add Book")
+                //Shows add book button only in main book list screen
+                if (!showAddScreen && selectedBook == null && currentDestination == BookTrackerDestination.MY_LIBRARY) {
+                    FloatingActionButton(onClick = { showAddScreen = true }) {
+                        Icon(Icons.Default.Add, contentDescription = "Add Book")
+                    }
                 }
             },
+
             bottomBar = {
                 // if line hides to bottom bar based on add book and book detail screen activity
                 if (!showAddScreen && selectedBook == null) {

--- a/app/src/main/java/com/example/booktracker/MainActivity.kt
+++ b/app/src/main/java/com/example/booktracker/MainActivity.kt
@@ -80,6 +80,8 @@ fun BookTrackerApp(onBooksLoaded: () -> Unit = {}) {
         var selectedBook by remember { mutableStateOf<Book?>(null) }
         var isSearching by remember { mutableStateOf(false) }
         var searchQuery by remember { mutableStateOf("") }
+        val navController = rememberNavController()
+        var currentDestination by remember { mutableStateOf(BookTrackerDestination.MY_LIBRARY) }
 
         // Collect books from flow (this replaces repository.books list)
         val books by repository.books.collectAsState(initial = emptyList())

--- a/app/src/main/java/com/example/booktracker/MainActivity.kt
+++ b/app/src/main/java/com/example/booktracker/MainActivity.kt
@@ -25,7 +25,11 @@ import com.example.booktracker.ui.theme.screens.AddBookScreen
 import com.example.booktracker.ui.theme.screens.BookDetailScreen
 import com.example.booktracker.ui.theme.components.BookListScreen
 import com.example.booktracker.ui.theme.components.SearchTopBar
-
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/example/booktracker/MainActivity.kt
+++ b/app/src/main/java/com/example/booktracker/MainActivity.kt
@@ -133,17 +133,19 @@ fun BookTrackerApp(onBooksLoaded: () -> Unit = {}) {
                 }
             },
             bottomBar = {
-                NavigationBar {
-                    BookTrackerDestination.entries.forEach { destination ->
-                        NavigationBarItem(
-                            selected = currentDestination ==destination,
-                            onClick = {
-                                currentDestination = destination
-                                navController.navigate(destination.route)
-                            },
-                            icon = { Text(if (destination == BookTrackerDestination.MY_LIBRARY) "📚" else "🔍") },
-                            label = { Text(destination.title) }
-                        )
+                if (!showAddScreen && selectedBook == null) {
+                    NavigationBar {
+                        BookTrackerDestination.entries.forEach { destination ->
+                            NavigationBarItem(
+                                selected = currentDestination == destination,
+                                onClick = {
+                                    currentDestination = destination
+                                    navController.navigate(destination.route)
+                                },
+                                icon = { Text(if (destination == BookTrackerDestination.MY_LIBRARY) "📚" else "🔍") },
+                                label = { Text(destination.title) }
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/example/booktracker/NavigationDestinations.kt
+++ b/app/src/main/java/com/example/booktracker/NavigationDestinations.kt
@@ -1,0 +1,6 @@
+package com.example.booktracker
+
+enum class BookTrackerDestination(val route: String, val title: String) {
+    MY_LIBRARY("my_library", "My Library"),
+    DISCOVER("discover", "Discover")
+}

--- a/app/src/main/java/com/example/booktracker/NavigationDestinations.kt
+++ b/app/src/main/java/com/example/booktracker/NavigationDestinations.kt
@@ -2,5 +2,5 @@ package com.example.booktracker
 
 enum class BookTrackerDestination(val route: String, val title: String) {
     MY_LIBRARY("my_library", "My Library"),
-    DISCOVER("discover", "Discover")
+    DISCOVER("discover", "Discover Books")
 }

--- a/app/src/main/java/com/example/booktracker/ui/theme/components/SearchTopBar.kt
+++ b/app/src/main/java/com/example/booktracker/ui/theme/components/SearchTopBar.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.example.booktracker.BookTrackerDestination
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -18,7 +19,8 @@ fun SearchTopBar(
     onSearchQueryChange: (String) -> Unit,
     onSearchToggle: () -> Unit,
     isDarkMode: Boolean,
-    onDarkModeToggle: () -> Unit
+    onDarkModeToggle: () -> Unit,
+    currentDestination: BookTrackerDestination
 ) {
     TopAppBar(
         title = {
@@ -35,7 +37,7 @@ fun SearchTopBar(
                     )
                 )
             } else {
-                Text("My Books")
+                Text(currentDestination.title)
             }
         },
         actions = {

--- a/app/src/main/java/com/example/booktracker/ui/theme/components/SearchTopBar.kt
+++ b/app/src/main/java/com/example/booktracker/ui/theme/components/SearchTopBar.kt
@@ -49,11 +49,13 @@ fun SearchTopBar(
             }
 
 
-            IconButton(onClick = onSearchToggle) {
-                Icon(
-                    imageVector = if (isSearching) Icons.Default.Close else Icons.Default.Search,
-                    contentDescription = if (isSearching) "Close search" else "Search books"
-                )
+            if (currentDestination == BookTrackerDestination.MY_LIBRARY) {
+                IconButton(onClick = onSearchToggle) {
+                    Icon(
+                        imageVector = if (isSearching) Icons.Default.Close else Icons.Default.Search,
+                        contentDescription = if (isSearching) "Close search" else "Search books"
+                    )
+                }
             }
         }
     )

--- a/app/src/main/java/com/example/booktracker/ui/theme/screens/DiscoverScreen.kt
+++ b/app/src/main/java/com/example/booktracker/ui/theme/screens/DiscoverScreen.kt
@@ -1,0 +1,8 @@
+package com.example.booktracker.ui.theme.screens
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun DiscoverScreen() {
+    // Add later
+}

--- a/app/src/main/java/com/example/booktracker/ui/theme/screens/DiscoverScreen.kt
+++ b/app/src/main/java/com/example/booktracker/ui/theme/screens/DiscoverScreen.kt
@@ -5,9 +5,15 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 
 @Composable
 fun DiscoverScreen() {
-    // Add later
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(text = "🔎", style = MaterialTheme.typography.displayLarge)
+        Text(text = "Discover Books", style = MaterialTheme.typography.headlineSmall)
+    }
 }

--- a/app/src/main/java/com/example/booktracker/ui/theme/screens/DiscoverScreen.kt
+++ b/app/src/main/java/com/example/booktracker/ui/theme/screens/DiscoverScreen.kt
@@ -1,6 +1,11 @@
 package com.example.booktracker.ui.theme.screens
 
 import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun DiscoverScreen() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ composeBom = "2025.07.00"
 ksp = "2.0.21-1.0.28"
 mockitoCore = "5.1.1"
 mockitoKotlin = "4.1.0"
+navigationCompose = "2.9.3"
 roomRuntime = "2.8.0"
 roomRuntimeVersion = "2.7.2"
 
@@ -23,6 +24,7 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "coreSplashscreen" }
 androidx-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "coreTesting" }
 androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomRuntimeVersion" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "roomRuntimeVersion" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "roomRuntimeVersion" }


### PR DESCRIPTION
## Add Bottom Navigation and Discover Screen

This update introduces a bottom navigation bar for screen switching and adds a Discover tab.

### Navigation Enhancements

- Added `NavigationDestination` enum to manage screen destinations
- Implemented bottom navigation bar with icons and labels
- Created `NavHost` setup to manage navigation between screens
- Added navigation state variables to `MainActivity`
- Passed `currentDestination` to `SearchTopBar` to handle conditional UI

### Discover Screen

- Added empty `DiscoverScreen` as a new destination
- Populated `DiscoverScreen` with basic placeholder content
- Renamed tab title to "Discover Books" for clarity

### Conditional UI Logic

- Hid bottom navigation bar on Add Book and Book Detail screens
- Displayed floating Add Book button only on the "My Library" tab
- Hid search button on the Discover tab

### UI Improvements

- Increased bottom navigation text size for better readability
- Added code comments for maintainability and clarity
